### PR TITLE
Fix movement sequence handling

### DIFF
--- a/Character.py
+++ b/Character.py
@@ -21,7 +21,8 @@ class Character:
             LerpPosInterval(self.model, duration=duration, pos=target_pos),
             Func(self.stop)
         )
-        move_sequence.start()
+
+        return move_sequence
 
     def get_position(self):
         return self.model.getPos()

--- a/TileMap.py
+++ b/TileMap.py
@@ -136,6 +136,8 @@ class TileMap(ShowBase):
                         move_interval = self.character.move_to(Vec3(step[0], step[1], 0.5))
                         intervals.append(move_interval)
 
+                    # Build one sequence from all intervals and start once
+
                     move_sequence = Sequence(*intervals, Func(self.camera_control.update_camera_focus))
                     move_sequence.start()
                     print(f"Moved to {step}")


### PR DESCRIPTION
## Summary
- return a `Sequence` from `Character.move_to` instead of starting it
- clarify in `tile_click_event` that the final sequence is built and started once

## Testing
- `python3 -m py_compile Character.py TileMap.py`
- ran a small script to create a dummy `Character` and start the returned interval

------
https://chatgpt.com/codex/tasks/task_e_68519400f55c832e9bdcabf9c499e3a3