### PR TITLE
Fix pathfinding grid indexing

### DIFF
--- a/TileMap.py
+++ b/TileMap.py
@@ -22,6 +22,7 @@ class TileMap(ShowBase):
         tile_size = 1
         map_radius = 5  # Number of tiles from the center to the edge, not including center
         map_width = map_height = map_radius * 2 + 1
+        self.map_radius = map_radius
         self.tiles = []
         self.grid = [[1 for _ in range(map_width)] for _ in range(map_height)]
 
@@ -126,19 +127,24 @@ class TileMap(ShowBase):
                 current_pos = self.character.get_position()
                 current_x, current_y = int(current_pos.getX()), int(current_pos.getY())
 
-                path = a_star(self.grid, (current_x, current_y), (snapped_x, snapped_y))
+                start_idx = (current_x + self.map_radius, current_y + self.map_radius)
+                end_idx = (snapped_x + self.map_radius, snapped_y + self.map_radius)
+
+                path = a_star(self.grid, start_idx, end_idx)
                 print("Calculated Path:", path)
 
                 if path:
                     intervals = []
                     for step in path:
-                        print(f"Moving character to {step}")
-                        move_interval = self.character.move_to(Vec3(step[0], step[1], 0.5))
+                        world_x = step[0] - self.map_radius
+                        world_y = step[1] - self.map_radius
+                        print(f"Moving character to {(world_x, world_y)}")
+                        move_interval = self.character.move_to(Vec3(world_x, world_y, 0.5))
                         intervals.append(move_interval)
 
                     move_sequence = Sequence(*intervals, Func(self.camera_control.update_camera_focus))
                     move_sequence.start()
-                    print(f"Moved to {step}")
+                    print(f"Moved to {(world_x, world_y)}")
 
                 print(f"After Update: Camera Hpr: {self.camera.getHpr()}")
                 print(f"After Update: Character Pos: {self.character.get_position()}")

--- a/pathfinding.py
+++ b/pathfinding.py
@@ -19,11 +19,20 @@ class Node:
 
 
 def a_star(grid, start, end):
-    """Perform A* Pathfinding."""
+    """Perform A* pathfinding on a grid using 0 based indices.
+
+    ``grid`` is expected to be a list-of-lists where ``1`` indicates a
+    walkable tile. ``start`` and ``end`` should already be translated into
+    grid coordinates starting at ``(0, 0)``. Negative coordinates are not
+    considered valid and will be ignored.
+    """
 
     # Create start and end node
     start_node = Node(start)
     end_node = Node(end)
+
+    height = len(grid)
+    width = len(grid[0]) if height > 0 else 0
 
     open_list = []
     closed_list = []
@@ -48,7 +57,14 @@ def a_star(grid, start, end):
         # Get the neighbors
         neighbors = []
         for new_position in [(0, -1), (1, 0), (0, 1), (-1, 0), (-1, -1), (1, 1), (-1, 1), (1, -1)]:
-            node_position = (current_node.position[0] + new_position[0], current_node.position[1] + new_position[1])
+            node_position = (
+                current_node.position[0] + new_position[0],
+                current_node.position[1] + new_position[1],
+            )
+
+            # Skip positions outside the grid
+            if not (0 <= node_position[0] < width and 0 <= node_position[1] < height):
+                continue
 
             # Check if the position is walkable
             if grid[node_position[1]][node_position[0]] == 0:


### PR DESCRIPTION
## Summary
- keep map radius for converting between world coords and grid indices
- convert start/end coordinates before calling `a_star`
- check bounds when generating neighbors
- clarify `a_star` docstring and grid assumptions

## Testing
- `python -m py_compile pathfinding.py TileMap.py Character.py Camera.py Controls.py collision.py DebugInfo.py`
- `python - <<'EOF'
import pathfinding

grid = [[1]*5 for _ in range(5)]
start = (2,2)
end = (4,4)
print('Path:', pathfinding.a_star(grid, start, end))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685194b7380c832e89f55ded063db1bc