### PR TITLE
Fix collision cleanup

### DIFF
--- a/collision.py
+++ b/collision.py
@@ -31,4 +31,6 @@ class CollisionControl:
             return None, None
 
     def cleanup(self):
-        self.pickerNP.removeNode()
+        """Reset the collision handler for the next ray cast without removing
+        the collision node itself."""
+        self.handler.clearEntries()


### PR DESCRIPTION
## Summary
- prevent collision detection from breaking after the first click by not removing the picker node

## Testing
- `python -m py_compile TileMap.py`
- `python -m py_compile collision.py`
- `python -m py_compile Character.py Controls.py Camera.py DebugInfo.py pathfinding.py`


------
https://chatgpt.com/codex/tasks/task_e_6851b8898ab0832e9a5d798e6880a577