### PR TITLE
Use explicit imports for clarity

### DIFF
--- a/Character.py
+++ b/Character.py
@@ -1,6 +1,6 @@
 #Character.py
 from panda3d.core import Vec3
-from direct.interval.IntervalGlobal import *
+from direct.interval.IntervalGlobal import Func, LerpPosInterval, Sequence
 
 class Character:
 

--- a/TileMap.py
+++ b/TileMap.py
@@ -1,5 +1,14 @@
 #TileMap.py
-from panda3d.core import *
+from panda3d.core import (
+    BitMask32,
+    CardMaker,
+    CollisionNode,
+    CollisionPlane,
+    ModifierButtons,
+    Plane,
+    Point3,
+    Vec3,
+)
 from direct.showbase.ShowBase import ShowBase
 import random
 from direct.interval.IntervalGlobal import Sequence, Func


### PR DESCRIPTION
## Summary
- avoid wildcard imports in `TileMap.py`
- avoid wildcard imports in `Character.py`

## Testing
- `python -m py_compile TileMap.py Character.py`

------
https://chatgpt.com/codex/tasks/task_e_6851f2d872f4832e80350716bb6f7bf4