### PR TITLE
Fix movement speed and sequence

### DIFF
--- a/Character.py
+++ b/Character.py
@@ -10,27 +10,33 @@ class Character:
         self.model.reparentTo(render)
         self.model.setPos(position)
         self.model.setScale(scale)
-        self.walking_speed = 1.0
+
+        # Base movement speed in tiles per second
+        self.speed = 1.0
+
+        self._active_sequence = None
 
     def log(self, *args, **kwargs):
         if self.debug:
             print(*args, **kwargs)
 
-    def move_to(self, target_pos):
-        self.log(f"Inside move_to. Target: {target_pos}")
-        start_pos = self.model.getPos()
-        distance = (target_pos - start_pos).length()  # Calculate the distance to the target
-        duration = distance / self.walking_speed      # Calculate the time it will take
+    def move_to(self, target_pos, duration):
+        """Create a movement interval towards ``target_pos`` taking ``duration`` seconds."""
+        self.log(f"Inside move_to. Target: {target_pos} Duration: {duration}")
 
-        move_sequence = Sequence(
-            LerpPosInterval(self.model, duration=duration, pos=target_pos),
-            Func(self.stop)
-        )
-
-        return move_sequence
+        move_interval = LerpPosInterval(self.model, duration=duration, pos=target_pos)
+        return Sequence(move_interval, Func(self.stop))
 
     def get_position(self):
         return self.model.getPos()
 
     def stop(self):
-        pass
+        self.log("Movement finished")
+
+    def start_sequence(self, sequence):
+        """Start a new movement sequence, cancelling any existing one."""
+        if self._active_sequence is not None and not self._active_sequence.isStopped():
+            self._active_sequence.finish()
+        self._active_sequence = sequence
+        sequence.start()
+

--- a/client.py
+++ b/client.py
@@ -1,6 +1,7 @@
 from panda3d.core import ModifierButtons, Vec3
 from direct.showbase.ShowBase import ShowBase
 from direct.interval.IntervalGlobal import Sequence, Func
+import math
 
 from Character import Character
 from DebugInfo import DebugInfo
@@ -101,15 +102,19 @@ class Client(ShowBase):
 
                 if path:
                     intervals = []
+                    prev_world_x, prev_world_y = current_x, current_y
                     for step in path:
                         world_x = step[0] - self.map_radius
                         world_y = step[1] - self.map_radius
                         self.log(f"Moving character to {(world_x, world_y)}")
-                        move_interval = self.character.move_to(Vec3(world_x, world_y, 0.5))
+                        distance = math.sqrt((world_x - prev_world_x) ** 2 + (world_y - prev_world_y) ** 2)
+                        duration = distance / self.character.speed
+                        move_interval = self.character.move_to(Vec3(world_x, world_y, 0.5), duration)
                         intervals.append(move_interval)
+                        prev_world_x, prev_world_y = world_x, world_y
 
                     move_sequence = Sequence(*intervals, Func(self.camera_control.update_camera_focus))
-                    move_sequence.start()
+                    self.character.start_sequence(move_sequence)
                     self.log(f"Moved to {(world_x, world_y)}")
 
                 self.log(f"After Update: Camera Hpr: {self.camera.getHpr()}")


### PR DESCRIPTION
## Summary
- add speed attribute to Character and track active animation
- update move_to to accept duration
- compute path step durations in client
- start new sequences via Character method

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851fe6e98a8832ebe8f8a1a420280de