### PR TITLE
Fix camera clock init

### DIFF
--- a/Camera.py
+++ b/Camera.py
@@ -1,5 +1,7 @@
-from panda3d.core import Vec3
-from Controls import Controls
+from panda3d.core import Vec3, ClockObject
+
+# Initialize the global clock for time-based movement
+globalClock = ClockObject.getGlobalClock()
 
 class CameraControl:
 


### PR DESCRIPTION
## Summary
- add ClockObject import
- set up `globalClock` once
- remove unused Controls import

## Testing
- `python -m py_compile Camera.py`

------
https://chatgpt.com/codex/tasks/task_e_685398e5fb68832ebf5589ddf3e7d24f