### PR TITLE
Add basic pathfinding tests

### DIFF
--- a/tests/test_pathfinding.py
+++ b/tests/test_pathfinding.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import pathfinding
+
+
+def test_a_star_open_grid():
+    grid = [
+        [1, 1],
+        [1, 1],
+    ]
+    path = pathfinding.a_star(grid, (0, 0), (1, 1))
+    assert path == [(0, 0), (1, 1)]
+
+
+def test_a_star_blocked_goal():
+    grid = [
+        [1, 1],
+        [1, 0],
+    ]
+    path = pathfinding.a_star(grid, (0, 0), (1, 1))
+    assert path is None


### PR DESCRIPTION
## Summary
- create `tests/` with `test_pathfinding.py`
- cover A* pathfinding on open grids and blocked goals
- configure path for tests so they can import project modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68539c5ad240832eb6d72c8d98805841