### PR TITLE
Fix UI slider duplicate keyword error and allow optional debug attach

### DIFF
--- a/runepy/debug/manager.py
+++ b/runepy/debug/manager.py
@@ -232,8 +232,11 @@ class DebugManager:
             self._ui_editor.disable()
             self._ui_editor = None
 
-    def attach(self, base: Any) -> None:
+    def attach(self, base: Any | None) -> None:
         """Bind the debug GUI to an existing :class:`ShowBase` instance."""
+
+        if base is None:
+            return
 
         if getattr(self, "_attached", False):
             return  # guard against double attach

--- a/runepy/ui/builder.py
+++ b/runepy/ui/builder.py
@@ -61,12 +61,16 @@ def _build_slider(parent: Any, spec: Dict[str, Any], mgr: Any) -> Any:
 
     # DirectSlider passes the new value as its first positional arg.
     # Preserve that parameter in the lambda.
+    props = dict(spec.get('props', {}))
+    rng = props.pop('range', spec.get('range', (0, 1)))
+    val = props.pop('value', getter())
+
     slider = DirectSlider(
         parent=parent,
-        range=spec.get('range', (0, 1)),
-        value=getter(),
+        range=rng,
+        value=val,
         command=lambda v, _setter=setter: _setter(float(v)),
-        **spec['props']
+        **props,
     )
     return slider
 


### PR DESCRIPTION
## Summary
- fix `_build_slider` to avoid duplicate `range`/`value` keyword arguments
- allow `DebugManager.attach` to be called with `None` base
- run test suite to ensure stability

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68589ab2811c832e952536abbb88f204