### PR TITLE
Fix UI editor hit test offsets

### DIFF
--- a/runepy/ui/editor/controller.py
+++ b/runepy/ui/editor/controller.py
@@ -101,27 +101,34 @@ class UIEditorController:
             return
         mpos = base.mouseWatcherNode.getMouse()
 
-        def _search(node: Any) -> Any | None:
+        def _search(node: Any, offset: tuple[float, float]) -> Any | None:
+            if hasattr(node, "getPos"):
+                try:
+                    p = node.getPos()
+                    offset = (offset[0] + p[0], offset[1] + p[2])
+                except Exception:
+                    pass
+
             for child in getattr(node, "getChildren", lambda: [])():
-                found = _search(child)
+                found = _search(child, offset)
                 if found is not None:
                     return found
+
             if getattr(node, "getPythonTag", lambda _n: None)("debug_gui"):
-                if hasattr(node, "__getitem__") and hasattr(node, "getPos"):
+                if hasattr(node, "__getitem__"):
                     try:
                         fs = node["frameSize"]
-                        pos = node.getPos()
-                        left = pos[0] + fs[0]
-                        right = pos[0] + fs[1]
-                        bottom = pos[2] + fs[2]
-                        top = pos[2] + fs[3]
+                        left = offset[0] + fs[0]
+                        right = offset[0] + fs[1]
+                        bottom = offset[1] + fs[2]
+                        top = offset[1] + fs[3]
                         if left <= mpos[0] <= right and bottom <= mpos[1] <= top:
                             return node
                     except Exception:
                         pass
             return None
 
-        widget = _search(self.root)
+        widget = _search(self.root, (0.0, 0.0))
         if widget is not None:
             self._begin_drag(widget, mpos)
 

--- a/tests/test_ui_editor_stub.py
+++ b/tests/test_ui_editor_stub.py
@@ -100,3 +100,28 @@ def test_begin_and_finish_drag(monkeypatch):
     fake_base.accepted["mouse1-up"]()
     assert ended
     editor.disable()
+
+
+def test_mouse_down_with_offset_root(monkeypatch):
+    from runepy.ui.editor import controller as ctr
+
+    fake_base = _FakeBase()
+    monkeypatch.setattr(ctr, "base", fake_base)
+
+    root = _FakeWidget(pos=(0.7, 0, 0.55), frame=(-1, 1, -1, 1))
+    child = _FakeWidget(pos=(0, 0, 0), frame=(-0.2, 0.2, -0.2, 0.2))
+    root.children.append(child)
+
+    editor = ctr.UIEditorController(root)
+    began: list[object] = []
+
+    def _begin(w, m):
+        began.append(w)
+
+    editor._begin_drag = _begin  # type: ignore[assignment]
+
+    editor.enable()
+    fake_base.mouseWatcherNode.pos = (0.7, 0.55)
+    fake_base.accepted["mouse1"]()
+    assert began and began[0] is child
+    editor.disable()


### PR DESCRIPTION
## Summary
- accumulate parent positions during UI hit testing
- test editor hit testing with offset root widget

## Testing
- `pip install numpy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c3febdb30832eaa91e85ef3db827a