### PR TITLE
Fix map save/load args and cleanup World init

### DIFF
--- a/runepy/client.py
+++ b/runepy/client.py
@@ -187,12 +187,12 @@ class Client(BaseApp):
     # ------------------------------------------------------------------
     def save_map(self, filename="map.json"):
         """Save the current world grid to ``filename``."""
-        self.editor.save_map(filename)
+        self.editor.save_map()
         print(f"Map saved to {filename}")
 
     def load_map(self, filename="map.json"):
         """Load a map from ``filename`` and rebuild the world."""
-        self.editor.load_map(filename)
+        self.editor.load_map()
         # World size may change during map load but pathfinding now stitches
         # regions dynamically so no cached grid is needed.
         print(f"Map loaded from {filename}")

--- a/runepy/editor_window.py
+++ b/runepy/editor_window.py
@@ -81,11 +81,11 @@ class EditorWindow(BaseApp):
         return task.cont
 
     def save_map(self):
-        self.editor.save_map("map.json")
+        self.editor.save_map()
         print("Map saved to map.json")
 
     def load_map(self):
-        self.editor.load_map("map.json")
+        self.editor.load_map()
         print("Map loaded from map.json")
 
 

--- a/runepy/map_editor.py
+++ b/runepy/map_editor.py
@@ -68,12 +68,12 @@ class MapEditor:
     # ------------------------------------------------------------------
     # Persistence helpers
     # ------------------------------------------------------------------
-    def save_map(self, filename):
+    def save_map(self):
         """Save all loaded regions to disk."""
         for region in self.world.region_manager.loaded.values():
             region.save()
 
-    def load_map(self, filename):
+    def load_map(self):
         """Load map data by clearing and reloading regions from disk."""
         self.world.region_manager.loaded.clear()
         self.world.region_manager.ensure(0, 0)
@@ -86,7 +86,7 @@ class MapEditor:
             self.save_callback()
         else:
             try:
-                self.save_map("map.json")
+                self.save_map()
                 print("Map saved to map.json")
             except Exception as exc:
                 print(f"Failed to save map: {exc}")
@@ -96,7 +96,7 @@ class MapEditor:
             self.load_callback()
         else:
             try:
-                self.load_map("map.json")
+                self.load_map()
                 print("Map loaded from map.json")
             except Exception as exc:
                 print(f"Failed to load map: {exc}")

--- a/runepy/world.py
+++ b/runepy/world.py
@@ -87,7 +87,6 @@ class World:
         radius=None,
         tile_size=1,
         debug=False,
-        map_file=None,
         progress_callback=None,
         view_radius=1,
     ):


### PR DESCRIPTION
## Summary
- remove unused `map_file` argument from `World.__init__`
- simplify `MapEditor.save_map` and `load_map` APIs
- update callers in client and editor window

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ede8bb968832eb87f39e48cfa462c