### PR TITLE
Add standalone UI editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ RunePy is a small demonstration project built with [Panda3D](https://www.panda3d
 | `runepy/debug/manager.py` | Toggleable debug window and related tools. |
 | `runepy/ui/builder.py` | Constructs GUI widgets from layout dictionaries. |
 | `runepy/ui/editor` | Package providing the simple UI editor. |
+| `runepy/ui_editor.py` | Standalone UI editing window. |
 
 ## Requirements
 
@@ -64,6 +65,12 @@ To launch the map editor instead of the game, run:
 
 ```bash
 python -m runepy.client --mode editor
+```
+
+To open the standalone UI editor, run:
+
+```bash
+python -m runepy.ui_editor
 ```
 
 A window will open containing a grid of tiles. The world loads 64×64 regions dynamically as you explore, letting the map expand as needed. Clicking on a tile moves the smiley‑face character to that location using pathfinding. Use the mouse wheel to zoom the camera in or out.

--- a/runepy/debug/manager.py
+++ b/runepy/debug/manager.py
@@ -215,23 +215,6 @@ class DebugManager:
         except Exception:
             pass
 
-    # ------------------------------------------------------------------
-    # UI editor integration
-    # ------------------------------------------------------------------
-    def toggle_ui_editor(self) -> None:
-        if self.window is None:
-            return
-        try:
-            from runepy.ui.editor.controller import UIEditorController
-        except Exception:
-            return
-        if getattr(self, "_ui_editor", None) is None:
-            self._ui_editor = UIEditorController(self.window)
-            self._ui_editor.enable()
-        else:
-            self._ui_editor.disable()
-            self._ui_editor = None
-
     def attach(self, base: Any | None) -> None:
         """Bind the debug GUI to an existing :class:`ShowBase` instance."""
 
@@ -248,7 +231,6 @@ class DebugManager:
         self.window.hide()  # start hidden
 
         base.accept('f1', self.window.toggleVisible)
-        base.accept('f2', self.toggle_ui_editor)
 
         print('[DebugManager] F1 bound')
 

--- a/runepy/ui_editor.py
+++ b/runepy/ui_editor.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Standalone UI editing application."""
+
+try:
+    from direct.showbase.ShowBase import ShowBase
+except Exception:  # pragma: no cover - Panda3D may be missing
+    ShowBase = object  # type: ignore
+
+from pathlib import Path
+from runepy.ui.editor import UIEditorController, dump_layout
+from runepy.debug import get_debug
+
+
+class UIEditorApp(ShowBase):
+    """Minimal window for editing UI layouts."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        dbg = get_debug()
+        dbg.attach(self)
+        self.editor: UIEditorController | None = None
+        if dbg.window is not None:
+            dbg.window.show()
+            self.editor = UIEditorController(dbg.window)
+            self.editor.enable()
+        self.accept("control-s", self.save_layout)
+        self.setBackgroundColor(0.1, 0.1, 0.1)
+
+    def save_layout(self) -> None:
+        """Save the current UI layout."""
+        if self.editor is None:
+            return
+        path = Path("debug_layout.json")
+        try:
+            dump_layout(get_debug().window, path)  # type: ignore[arg-type]
+            print(f"Layout saved to {path}")
+        except Exception:
+            pass
+
+
+def main() -> None:
+    app = UIEditorApp()
+    app.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- remove in-game UI editor toggle
- add `ui_editor.py` to launch a window dedicated to editing UI layouts
- document new UI editor command in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ee0f8a324832eb385a4192557318f