### PR TITLE
Update texture editor frame color

### DIFF
--- a/src/runepy/texture_editor.py
+++ b/src/runepy/texture_editor.py
@@ -28,7 +28,7 @@ class TextureEditor:
         self._orig_click_handler = None
         if DirectFrame is not object:
             self.frame = DirectFrame(
-                frameColor=(0, 0, 0, 0.7),
+                frameColor=(0, 0, 0, 1),
                 frameSize=(-0.6, 0.6, -0.6, 0.6),
                 pos=(0, 0, 0.2),
             )


### PR DESCRIPTION
## Summary
- adjust texture editor default frame color to be fully opaque

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889203cb8e8832eb93508d560b86a69