### PR TITLE
Fix texture editor click override

### DIFF
--- a/src/runepy/texture_editor.py
+++ b/src/runepy/texture_editor.py
@@ -69,7 +69,7 @@ class TextureEditor:
         if hasattr(self.base, "tile_click_event"):
             try:
                 self._orig_click_handler = self.base.tile_click_event
-                self.base.ignore("mouse1")
+                self.base.ignore("mouse1", self._orig_click_handler)
             except Exception:
                 self._orig_click_handler = None
         rx, ry = world_to_region(tile_x, tile_y)

--- a/tests/test_editor_window_click_override.py
+++ b/tests/test_editor_window_click_override.py
@@ -10,10 +10,17 @@ class _FakeBase:
         self.camera = NodePath('camera')
         self.taskMgr = types.SimpleNamespace(add=lambda *a, **k: None)
         self.mouseWatcherNode = None
+        def click():
+            self.clicked = getattr(self, 'clicked', 0) + 1
+        self.tile_click_event = click
     def accept(self, evt, func):
         self.accepted[evt] = func
-    def ignore(self, evt):
-        self.accepted.pop(evt, None)
+    def ignore(self, evt, func=None):
+        if func is None:
+            self.accepted.pop(evt, None)
+        else:
+            if evt in self.accepted and self.accepted[evt] is func:
+                self.accepted.pop(evt)
     def disableMouse(self):
         pass
     def setBackgroundColor(self, *a, **k):

--- a/tests/test_keybinding_manager.py
+++ b/tests/test_keybinding_manager.py
@@ -9,7 +9,7 @@ class FakeBase:
     def accept(self, evt: str, func):
         self.accepted.append((evt, func))
 
-    def ignore(self, evt: str):
+    def ignore(self, evt: str, func=None):
         self.ignored.append(evt)
 
 

--- a/tests/test_options_menu.py
+++ b/tests/test_options_menu.py
@@ -9,7 +9,7 @@ class FakeBase:
     def accept(self, evt: str, func):
         self.accepted.append((evt, func))
 
-    def ignore(self, evt: str):
+    def ignore(self, evt: str, func=None):
         self.ignored.append(evt)
 
 

--- a/tests/test_texture_editor_click_override.py
+++ b/tests/test_texture_editor_click_override.py
@@ -5,12 +5,17 @@ from runepy.texture_editor import TextureEditor
 class _FakeBase:
     def __init__(self):
         self.accepted = {}
+        def click():
+            self.clicked = getattr(self, 'clicked', 0) + 1
+        self.tile_click_event = click
     def accept(self, evt, func):
         self.accepted[evt] = func
-    def ignore(self, evt):
-        self.accepted.pop(evt, None)
-    def tile_click_event(self):
-        self.clicked = getattr(self, 'clicked', 0) + 1
+    def ignore(self, evt, func=None):
+        if func is None:
+            self.accepted.pop(evt, None)
+        else:
+            if evt in self.accepted and self.accepted[evt] is func:
+                self.accepted.pop(evt)
 
 
 def test_texture_editor_ignores_game_click(monkeypatch, tmp_path):

--- a/tests/test_texture_editor_other_handlers.py
+++ b/tests/test_texture_editor_other_handlers.py
@@ -1,0 +1,52 @@
+import types
+from runepy.world import World
+from runepy.texture_editor import TextureEditor
+
+class _MultiBase:
+    def __init__(self):
+        self.accepted = {}
+    def accept(self, evt, func):
+        self.accepted.setdefault(evt, []).append(func)
+    def ignore(self, evt, func=None):
+        if func is None:
+            self.accepted.pop(evt, None)
+        else:
+            handlers = self.accepted.get(evt)
+            if handlers and func in handlers:
+                handlers.remove(func)
+                if not handlers:
+                    self.accepted.pop(evt)
+    def tile_click_event(self):
+        self.clicked = getattr(self, 'clicked', 0) + 1
+    def other_handler(self):
+        self.other = getattr(self, 'other', 0) + 1
+
+
+def test_other_handlers_survive(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    base = _MultiBase()
+    world = World(view_radius=1)
+    editor = TextureEditor(base, world)
+
+    base.accept('mouse1', base.tile_click_event)
+    base.accept('mouse1', base.other_handler)
+
+    for f in list(base.accepted['mouse1']):
+        f()
+    assert base.clicked == 1 and base.other == 1
+
+    base.clicked = 0
+    base.other = 0
+
+    editor.open(0, 0)
+    if 'mouse1' in base.accepted:
+        for f in list(base.accepted['mouse1']):
+            f()
+    assert base.clicked == 0
+    assert base.other == 1
+
+    editor.close()
+    for f in list(base.accepted['mouse1']):
+        f()
+    assert base.clicked == 1
+    assert base.other == 2

--- a/tests/test_ui_editor_click_override.py
+++ b/tests/test_ui_editor_click_override.py
@@ -25,13 +25,17 @@ class _FakeBase:
         self.mouseWatcherNode = _FakeMouseWatcher()
         self.taskMgr = _FakeTaskMgr()
         self.accepted = {}
+        def click():
+            self.clicked = getattr(self, 'clicked', 0) + 1
+        self.tile_click_event = click
     def accept(self, evt, func):
         self.accepted[evt] = func
-    def ignore(self, evt):
-        self.accepted.pop(evt, None)
-    # game click handler
-    def tile_click_event(self):
-        self.clicked = getattr(self, 'clicked', 0) + 1
+    def ignore(self, evt, func=None):
+        if func is None:
+            self.accepted.pop(evt, None)
+        else:
+            if evt in self.accepted and self.accepted[evt] is func:
+                self.accepted.pop(evt)
 
 class _FakeWidget:
     def __init__(self, pos=(0,0,0), frame=(-1,1,-1,1)):

--- a/tests/test_ui_editor_extra.py
+++ b/tests/test_ui_editor_extra.py
@@ -86,8 +86,12 @@ def test_enable_disable(monkeypatch):
             self.accepted = {}
         def accept(self, evt, func):
             self.accepted[evt] = func
-        def ignore(self, evt):
-            self.accepted.pop(evt, None)
+        def ignore(self, evt, func=None):
+            if func is None:
+                self.accepted.pop(evt, None)
+            else:
+                if evt in self.accepted and self.accepted[evt] is func:
+                    self.accepted.pop(evt)
 
     class _Widget:
         def __init__(self, color=(1,1,1,1)):
@@ -154,8 +158,12 @@ def test_enable_disable_drag_task(monkeypatch):
             self.accepted = {}
         def accept(self, evt, func):
             self.accepted[evt] = func
-        def ignore(self, evt):
-            self.accepted.pop(evt, None)
+        def ignore(self, evt, func=None):
+            if func is None:
+                self.accepted.pop(evt, None)
+            else:
+                if evt in self.accepted and self.accepted[evt] is func:
+                    self.accepted.pop(evt)
 
     class _Widget:
         def __init__(self, color=(1,1,1,1)):

--- a/tests/test_ui_editor_stub.py
+++ b/tests/test_ui_editor_stub.py
@@ -38,11 +38,14 @@ class _FakeBase:
         self.taskMgr = _FakeTaskMgr()
         self.accepted: dict[str, callable] = {}
         self.ignored: list[str] = []
+        def click():
+            self.clicked = getattr(self, 'clicked', 0) + 1
+        self.tile_click_event = click
 
     def accept(self, evt: str, func):  # pragma: no cover - stub
         self.accepted[evt] = func
 
-    def ignore(self, evt: str):  # pragma: no cover - stub
+    def ignore(self, evt: str, func=None):  # pragma: no cover - stub
         self.ignored.append(evt)
 
 


### PR DESCRIPTION
## Summary
- stop removing all mouse1 handlers when starting the texture editor
- only restore the saved handler on close
- test that other mouse1 handlers remain active
- update fakes in tests for selective ignore semantics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889232c1918832ea12537263ed87595