### PR TITLE
Refactor client initialization helpers

### DIFF
--- a/src/runepy/__init__.py
+++ b/src/runepy/__init__.py
@@ -7,6 +7,8 @@ from .array_map import RegionArrays
 from .map_manager import MapManager
 from .terrain import TerrainTile, FLAG_BLOCKED
 from .ui.manager import UIManager
+from .pathfinding import Pathfinder
+from .input_binder import InputBinder
 
 try:
     from .base_app import BaseApp
@@ -21,4 +23,6 @@ __all__ = [
     "TerrainTile",
     "FLAG_BLOCKED",
     "UIManager",
+    "Pathfinder",
+    "InputBinder",
 ]

--- a/src/runepy/input_binder.py
+++ b/src/runepy/input_binder.py
@@ -1,0 +1,43 @@
+import logging
+from runepy.options_menu import KeyBindingManager, OptionsMenu
+
+
+logger = logging.getLogger(__name__)
+
+
+class InputBinder:
+    """Bind mouse and keyboard events for the client."""
+
+    def __init__(self, base, pathfinder, debug_info, key_bindings=None):
+        self.base = base
+        self.pathfinder = pathfinder
+        self.debug_info = debug_info
+
+        self.key_manager = KeyBindingManager(base, key_bindings or {"open_menu": "escape"})
+        self.options_menu = OptionsMenu(base, self.key_manager)
+        base.key_manager = self.key_manager
+        base.options_menu = self.options_menu
+        self.key_manager.bind("open_menu", self.options_menu.toggle)
+
+        self.tile_click_event_ref = self.on_click
+        base.tile_click_event_ref = self.on_click
+        base.accept("mouse1", self.tile_click_event_ref)
+        if self.debug_info is not None:
+            base.accept("f3", self.debug_info.toggle_region_info)
+
+    def on_click(self):
+        if self.options_menu.visible:
+            return
+        if not self.base.mouseWatcherNode.hasMouse():
+            return
+        mpos = self.base.mouseWatcherNode.getMouse()
+        self.base.camera.setH(0)
+        self.base.collision_control.update_ray(self.base.camNode, mpos)
+        self.base.collision_control.traverser.traverse(self.base.render)
+        collided_obj, pickedPos = self.base.collision_control.get_collided_object(self.base.render)
+        if collided_obj:
+            snapped_x = round(pickedPos.getX())
+            snapped_y = round(pickedPos.getY())
+            self.pathfinder.move_along_path(snapped_x, snapped_y)
+        self.base.collision_control.cleanup()
+

--- a/src/runepy/pathfinding.py
+++ b/src/runepy/pathfinding.py
@@ -4,7 +4,14 @@ import heapq
 from dataclasses import dataclass
 from typing import Iterable, Tuple, Union
 
+import logging
+import math
+from panda3d.core import Vec3
+from direct.interval.IntervalGlobal import Sequence, Func
+
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(order=True)
@@ -103,3 +110,56 @@ def a_star(
             heapq.heappush(open_heap, (g_score + h_score, neighbor))
 
     return None
+
+class Pathfinder:
+    """Helper to compute paths and move a character along them."""
+
+    def __init__(self, character, world, camera_control, debug=False):
+        self.character = character
+        self.world = world
+        self.camera_control = camera_control
+        self.debug = debug
+
+    def log(self, *args, **kwargs):
+        if self.debug:
+            logger.debug(*args, **kwargs)
+
+    def move_along_path(self, target_x: int, target_y: int) -> None:
+        """Find a path to ``(target_x, target_y)`` and move the character."""
+        current_pos = self.character.get_position()
+        target_pos = Vec3(target_x, target_y, current_pos.getZ())
+        if (current_pos - target_pos).length() <= 0.1:
+            self.log("Already at destination")
+            return
+
+        self.character.cancel_movement()
+        current_x, current_y = int(current_pos.getX()), int(current_pos.getY())
+
+        stitched, off_x, off_y = self.world.walkable_window(current_x, current_y)
+        start_idx = (current_x - off_x, current_y - off_y)
+        end_idx = (target_x - off_x, target_y - off_y)
+
+        path = a_star(stitched, start_idx, end_idx)
+        self.log("Calculated Path:", path)
+        if not path:
+            return
+        if path and path[0] == start_idx:
+            path = path[1:]
+        if not path:
+            self.log("Already at destination")
+            return
+
+        intervals = []
+        prev_x, prev_y = current_pos.getX(), current_pos.getY()
+        for step in path:
+            world_x = step[0] + off_x
+            world_y = step[1] + off_y
+            distance = math.sqrt((world_x - prev_x) ** 2 + (world_y - prev_y) ** 2)
+            duration = distance / self.character.speed
+            move_interval = self.character.move_to(Vec3(world_x, world_y, 0.5), duration)
+            intervals.append(move_interval)
+            prev_x, prev_y = world_x, world_y
+
+        seq = Sequence(*intervals, Func(self.camera_control.update_camera_focus))
+        self.character.start_sequence(seq)
+


### PR DESCRIPTION
## Summary
- add `Pathfinder` for computing paths and sequencing movement
- create `InputBinder` to centralize keyboard and mouse bindings
- delegate movement and input handling in `Client` to the new helpers
- export the helpers in package `__all__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68895ce046b8832ebc07fec31138483b