### PR TITLE
Skip benchmark tests when pytest-benchmark not installed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,11 @@ dependencies = [
     "numpy",
 ]
 
+[project.optional-dependencies]
+test = [
+    "pytest-benchmark",
+]
+
 [project.scripts]
 runepy = "runepy.client:main"
 

--- a/tests/benchmarks/test_pathfinding_bench.py
+++ b/tests/benchmarks/test_pathfinding_bench.py
@@ -12,6 +12,10 @@ optimisation):
 - 200×200 grid: ~6.79 ms
 """
 
+import pytest
+
+pytest.importorskip("pytest_benchmark")
+
 import numpy as np
 
 from runepy.pathfinding import a_star

--- a/tests/benchmarks/test_region_streaming_bench.py
+++ b/tests/benchmarks/test_region_streaming_bench.py
@@ -5,6 +5,10 @@ multiple times directly versus loading through ``RegionManager`` which caches
 previously loaded regions in memory.
 """
 
+import pytest
+
+pytest.importorskip("pytest_benchmark")
+
 from runepy.world.region import Region
 from runepy.world.manager import RegionManager
 


### PR DESCRIPTION
## Summary
- skip benchmark modules if pytest-benchmark plugin is missing
- declare pytest-benchmark as an optional test dependency

## Testing
- `pytest tests/benchmarks/test_pathfinding_bench.py tests/benchmarks/test_region_streaming_bench.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_689f5ad7dffc832ea811f190e8c25d0f