### PR TITLE
fix: update Ruff invocation in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           pip install -r requirements.txt -r requirements-dev.txt
       - name: Ruff
-        run: ruff --output-format=github
+        run: ruff check --output-format=github .
       - name: Mypy
         run: mypy --strict
 


### PR DESCRIPTION
## Summary
- update Ruff step to use `ruff check`

## Testing
- `ruff check --output-format=github .`
- `pre-commit run --files .github/workflows/ci.yml` *(fails: Username prompt for 'https://github.com')*


------
https://chatgpt.com/codex/tasks/task_e_689fa7082ec4832e8a0f186bc16b985c