### PR TITLE
Pin ruff version in development requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,4 @@ pre-commit
 pytest
 pytest-benchmark
 pytest-cov
-ruff
+ruff==0.4.4


### PR DESCRIPTION
## Summary
- pin `ruff` to `0.4.4` in `requirements-dev.txt` to match pre-commit hook

## Testing
- `pre-commit run --files requirements-dev.txt` *(fails: Authentication failed for 'https://github.com/pre-commit/pyproject-toml/')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a33a3b26ac832ebaa91c68dc73749a