### PR TITLE
chore: reorder imports

### DIFF
--- a/src/runepy/__init__.py
+++ b/src/runepy/__init__.py
@@ -1,15 +1,16 @@
 """RunePy package."""
 
-from . import logging_config  # noqa: F401
-
-from . import pathfinding
+from . import (
+    logging_config,  # noqa: F401
+    pathfinding,
+    verbose,
+)
 from .array_map import RegionArrays
-from .map_manager import MapManager
-from .terrain import TerrainTile, FLAG_BLOCKED
-from .ui.manager import UIManager
-from .pathfinding import Pathfinder
 from .input_binder import InputBinder
-from . import verbose
+from .map_manager import MapManager
+from .pathfinding import Pathfinder
+from .terrain import FLAG_BLOCKED, TerrainTile
+from .ui.manager import UIManager
 
 try:
     from .base_app import BaseApp

--- a/src/runepy/base_app.py
+++ b/src/runepy/base_app.py
@@ -1,5 +1,6 @@
 from direct.showbase.ShowBase import ShowBase
 from panda3d.core import loadPrcFileData
+
 from runepy.loading_screen import LoadingScreen
 
 

--- a/src/runepy/camera.py
+++ b/src/runepy/camera.py
@@ -1,4 +1,4 @@
-from panda3d.core import Vec3, ClockObject
+from panda3d.core import ClockObject, Vec3
 
 # Initialize the global clock for time-based movement
 globalClock = ClockObject.getGlobalClock()

--- a/src/runepy/character.py
+++ b/src/runepy/character.py
@@ -1,7 +1,9 @@
 # Character.py
 import logging
-from panda3d.core import Vec3
+
 from direct.interval.IntervalGlobal import Func, LerpPosInterval, Sequence
+from panda3d.core import Vec3
+
 from runepy.world.region import world_to_region
 
 logger = logging.getLogger(__name__)

--- a/src/runepy/client.py
+++ b/src/runepy/client.py
@@ -1,29 +1,29 @@
+import argparse
+import atexit
 import logging
+
 from panda3d.core import ModifierButtons, Vec3
+
 try:
     import direct.showbase.ShowBaseGlobal as sbg
 except Exception:  # pragma: no cover - Panda3D may be missing
     sbg = None
-from runepy.utils import update_tile_hover as util_update_tile_hover
-import argparse
-from runepy import verbose
 
-logger = logging.getLogger(__name__)
-
-from runepy.base_app import BaseApp
-
-from runepy.character import Character
-from runepy.debuginfo import DebugInfo
-from runepy.camera import CameraControl
-from runepy.controls import Controls
-from runepy.world.world import World
 from constants import REGION_SIZE, VIEW_RADIUS
-from runepy.pathfinding import Pathfinder
-from runepy.input_binder import InputBinder
+from runepy import verbose
+from runepy.base_app import BaseApp
+from runepy.camera import CameraControl
+from runepy.character import Character
 from runepy.collision import CollisionControl
 from runepy.config import load_state, save_state
-import atexit
+from runepy.controls import Controls
+from runepy.debuginfo import DebugInfo
+from runepy.input_binder import InputBinder
+from runepy.pathfinding import Pathfinder
+from runepy.utils import update_tile_hover as util_update_tile_hover
+from runepy.world.world import World
 
+logger = logging.getLogger(__name__)
 
 class Client(BaseApp):
     """Application entry point that opens the game window."""

--- a/src/runepy/collision.py
+++ b/src/runepy/collision.py
@@ -1,9 +1,9 @@
 # collision.py
 from panda3d.core import (
-    CollisionRay,
+    BitMask32,
     CollisionHandlerQueue,
     CollisionNode,
-    BitMask32,
+    CollisionRay,
     CollisionTraverser,
 )
 

--- a/src/runepy/debug/manager.py
+++ b/src/runepy/debug/manager.py
@@ -6,14 +6,15 @@ module is unavailable.
 """
 
 from __future__ import annotations
-from runepy.logging_config import LOG_DIR
-import logging
-logger = logging.getLogger(__name__)
-from pathlib import Path
+
 import datetime
+import logging
+from pathlib import Path
+from typing import Any, Optional
 
-from typing import Optional, Any
+from runepy.logging_config import LOG_DIR
 
+logger = logging.getLogger(__name__)
 
 class NullDebugManager:
     """Fallback manager used when Panda3D is unavailable."""
@@ -153,8 +154,8 @@ class DebugManager:
             if self.base is None:
                 return
             base = self.base
-            from runepy.world.region import world_to_region, Region
             from constants import REGION_SIZE
+            from runepy.world.region import Region, world_to_region
             world = getattr(base, "world", None)
             char = getattr(base, "character", None)
             if world is None or char is None:

--- a/src/runepy/editor_toolbar.py
+++ b/src/runepy/editor_toolbar.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 try:
-    from direct.gui.DirectGui import DirectFrame, DirectOptionMenu, DirectButton
+    from direct.gui.DirectGui import DirectButton, DirectFrame, DirectOptionMenu
 except Exception:  # pragma: no cover - Panda3D may be missing
     DirectFrame = object  # type: ignore
     DirectOptionMenu = object  # type: ignore

--- a/src/runepy/editor_window.py
+++ b/src/runepy/editor_window.py
@@ -1,15 +1,16 @@
 import logging
-from runepy.base_app import BaseApp
-from runepy.world.world import World
+
 from constants import REGION_SIZE, VIEW_RADIUS
-from runepy.map_editor import MapEditor
-from runepy.editor_toolbar import EditorToolbar
+from runepy.base_app import BaseApp
 from runepy.camera import FreeCameraControl
+from runepy.controls import Controls
+from runepy.debug import get_debug
+from runepy.editor_toolbar import EditorToolbar
+from runepy.map_editor import MapEditor
 from runepy.options_menu import KeyBindingManager, OptionsMenu
 from runepy.ui.editor import UIEditorController
-from runepy.controls import Controls
 from runepy.utils import update_tile_hover as util_update_tile_hover
-from runepy.debug import get_debug
+from runepy.world.world import World
 
 logger = logging.getLogger(__name__)
 

--- a/src/runepy/input_binder.py
+++ b/src/runepy/input_binder.py
@@ -1,6 +1,6 @@
 import logging
-from runepy.options_menu import KeyBindingManager, OptionsMenu
 
+from runepy.options_menu import KeyBindingManager, OptionsMenu
 
 logger = logging.getLogger(__name__)
 

--- a/src/runepy/map_editor.py
+++ b/src/runepy/map_editor.py
@@ -1,9 +1,10 @@
 import logging
-from runepy.utils import get_tile_from_mouse
-from runepy.world.region import world_to_region, local_tile
-from runepy.terrain import FLAG_BLOCKED
+
 from constants import REGION_SIZE
+from runepy.terrain import FLAG_BLOCKED
 from runepy.texture_editor import TextureEditor
+from runepy.utils import get_tile_from_mouse
+from runepy.world.region import local_tile, world_to_region
 
 logger = logging.getLogger(__name__)
 

--- a/src/runepy/options_menu.py
+++ b/src/runepy/options_menu.py
@@ -1,14 +1,16 @@
+import copy
+
 from direct.gui.DirectGui import (
+    DirectButton,
+    DirectEntry,
     DirectFrame,
     DirectLabel,
-    DirectEntry,
-    DirectButton,
 )
-from panda3d.core import TextNode
 from direct.showbase.DirectObject import DirectObject
+from panda3d.core import TextNode
+
 from runepy.ui.common import create_ui
 from runepy.ui.layouts import OPTIONS_MENU_LAYOUT
-import copy
 
 
 class KeyBindingManager(DirectObject):

--- a/src/runepy/pathfinding.py
+++ b/src/runepy/pathfinding.py
@@ -1,14 +1,13 @@
 # pathfinding.py
 
 import heapq
-from typing import Iterable, Tuple, Union
-
 import logging
 import math
-from panda3d.core import Vec3
-from direct.interval.IntervalGlobal import Sequence, Func
+from typing import Iterable, Tuple, Union
 
 import numpy as np
+from direct.interval.IntervalGlobal import Func, Sequence
+from panda3d.core import Vec3
 
 logger = logging.getLogger(__name__)
 

--- a/src/runepy/terrain.py
+++ b/src/runepy/terrain.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from typing import Tuple
 
-
 #: Tile flag bitmask for a blocked or non-walkable tile
 FLAG_BLOCKED = 0x1
 

--- a/src/runepy/texture_editor.py
+++ b/src/runepy/texture_editor.py
@@ -1,20 +1,19 @@
-from __future__ import annotations
-
 """Simple per-tile texture editor."""
 
-try:
-    from direct.gui.DirectGui import DirectFrame, DirectButton
-except Exception:  # pragma: no cover - Panda3D may be missing
-    DirectFrame = object  # type: ignore
-    DirectButton = object  # type: ignore
+from __future__ import annotations
 
-from runepy.ui.common import create_ui
-from runepy.ui.layouts import TEXTURE_EDITOR_LAYOUT
 from typing import Any
 
 from constants import REGION_SIZE
-from runepy.world.region import world_to_region, local_tile
+from runepy.ui.common import create_ui
+from runepy.ui.layouts import TEXTURE_EDITOR_LAYOUT
+from runepy.world.region import local_tile, world_to_region
 
+try:
+    from direct.gui.DirectGui import DirectButton, DirectFrame
+except Exception:  # pragma: no cover - Panda3D may be missing
+    DirectFrame = object  # type: ignore
+    DirectButton = object  # type: ignore
 
 class TextureEditor:
     """Lightweight tool for editing per-tile textures."""

--- a/src/runepy/ui/builder.py
+++ b/src/runepy/ui/builder.py
@@ -5,12 +5,12 @@ from typing import Any, Dict
 
 try:
     from direct.gui.DirectGui import (
-        DirectFrame,
         DirectButton,
-        DirectSlider,
-        DirectLabel,
         DirectEntry,
+        DirectFrame,
+        DirectLabel,
         DirectOptionMenu,
+        DirectSlider,
         DirectWaitBar,
     )
 except Exception:  # pragma: no cover - Panda3D may be missing

--- a/src/runepy/ui/common.py
+++ b/src/runepy/ui/common.py
@@ -1,10 +1,10 @@
-from __future__ import annotations
-
 """Shared UI helpers."""
+
+from __future__ import annotations
 
 from typing import Any, Dict
 
-from .builder import build_ui, StubWidget
+from .builder import StubWidget, build_ui
 
 try:
     from direct.gui.DirectGui import DirectFrame

--- a/src/runepy/ui/editor/controller.py
+++ b/src/runepy/ui/editor/controller.py
@@ -1,7 +1,11 @@
 """UI editing controller."""
 from __future__ import annotations
+
 import logging
-logger = logging.getLogger(__name__)
+import os
+import sys
+from pathlib import Path
+from typing import Any
 
 try:
     from direct.showbase.ShowBaseGlobal import base
@@ -11,25 +15,21 @@ except Exception:  # pragma: no cover - Panda3D may be missing
     Task = object  # type: ignore
 
 try:
-    from direct.gui.DirectGui import DirectFrame, DirectEntry, DirectLabel
+    from direct.gui.DirectGui import DirectEntry, DirectFrame, DirectLabel
 except Exception:  # pragma: no cover - Panda3D may be missing
     DirectFrame = object  # type: ignore
     DirectEntry = object  # type: ignore
     DirectLabel = object  # type: ignore
-
-from pathlib import Path
-from typing import Any
-import os
-import sys
 
 try:
     from panda3d.core import WindowProperties
 except Exception:  # pragma: no cover - Panda3D may be missing
     WindowProperties = object  # type: ignore
 
-from .serializer import dump_layout
 from .gizmos import SelectionGizmo
+from .serializer import dump_layout
 
+logger = logging.getLogger(__name__)
 
 class UIEditorController:
     """Basic UI layout editor."""

--- a/src/runepy/ui/manager.py
+++ b/src/runepy/ui/manager.py
@@ -1,19 +1,18 @@
-from __future__ import annotations
-
 """Simple UI manager for loading and toggling interface layouts."""
 
-from pathlib import Path
+from __future__ import annotations
+
 import importlib
 import json
+from pathlib import Path
 from typing import Any, Dict
 
-from .builder import build_ui, StubWidget
+from .builder import StubWidget, build_ui
 
 try:
     from direct.gui.DirectGui import DirectFrame
 except Exception:  # pragma: no cover - Panda3D may be missing
     DirectFrame = StubWidget  # type: ignore
-
 
 class UIManager:
     """Manage GUI layouts and their root frames."""

--- a/src/runepy/ui_editor.py
+++ b/src/runepy/ui_editor.py
@@ -1,19 +1,19 @@
+"""Standalone UI editing application."""
+
 from __future__ import annotations
 
 import logging
-"""Standalone UI editing application."""
+from pathlib import Path
 
 try:
     from direct.showbase.ShowBase import ShowBase
 except Exception:  # pragma: no cover - Panda3D may be missing
     ShowBase = object  # type: ignore
 
-from pathlib import Path
-from runepy.ui.editor import UIEditorController, dump_layout
 from runepy.debug import get_debug
+from runepy.ui.editor import UIEditorController, dump_layout
 
 logger = logging.getLogger(__name__)
-
 
 class UIEditorApp(ShowBase):
     """Minimal window for editing UI layouts."""

--- a/src/runepy/utils.py
+++ b/src/runepy/utils.py
@@ -1,7 +1,8 @@
 # Utility functions shared across modules
-from panda3d.core import MouseWatcher, Plane, Point3, Vec3
 import math
 from contextlib import contextmanager
+
+from panda3d.core import MouseWatcher, Plane, Point3, Vec3
 
 
 def get_mouse_tile_coords(

--- a/src/runepy/verbose.py
+++ b/src/runepy/verbose.py
@@ -1,7 +1,8 @@
+import atexit
 import logging
 import sys
-import atexit
 from types import FrameType
+
 from .logging_config import LOG_DIR
 
 logger = logging.getLogger("runepy.verbose")

--- a/src/runepy/world/__init__.py
+++ b/src/runepy/world/__init__.py
@@ -1,6 +1,6 @@
-from .world import World, TileData
-from .region import Region, world_to_region, local_tile
 from .manager import RegionManager
+from .region import Region, local_tile, world_to_region
+from .world import TileData, World
 
 __all__ = [
     "World",

--- a/src/runepy/world/manager.py
+++ b/src/runepy/world/manager.py
@@ -5,6 +5,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Dict, Set, Tuple
 
 from constants import REGION_SIZE, VIEW_RADIUS
+
 from .base_manager import BaseRegionManager
 
 try:

--- a/src/runepy/world/region.py
+++ b/src/runepy/world/region.py
@@ -8,9 +8,9 @@ from dataclasses import dataclass
 from typing import ClassVar, Dict, List, Tuple
 
 import numpy as np
-from runepy.paths import MAPS_DIR
 
 from constants import REGION_SIZE
+from runepy.paths import MAPS_DIR
 
 try:
     from panda3d.core import (

--- a/src/runepy/world/world.py
+++ b/src/runepy/world/world.py
@@ -5,11 +5,12 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Tuple
 
 import numpy as np
-from .manager import RegionManager
-from .region import world_to_region, local_tile
 
 from constants import REGION_SIZE
 from runepy.terrain import FLAG_BLOCKED
+
+from .manager import RegionManager
+from .region import local_tile, world_to_region
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +55,7 @@ class TileData:
         return tile
 
 try:
+    import direct.showbase.ShowBaseGlobal as sbg
     from panda3d.core import (
         BitMask32,
         CardMaker,
@@ -65,13 +67,12 @@ try:
         GeomVertexData,
         GeomVertexFormat,
         GeomVertexWriter,
+        LineSegs,
+        NodePath,
         Plane,
         Point3,
         Vec3,
-        LineSegs,
-        NodePath,
     )
-    import direct.showbase.ShowBaseGlobal as sbg
 except Exception:  # pragma: no cover - Panda3D may be missing during tests
     BitMask32 = CardMaker = CollisionNode = CollisionPlane = Plane = None
     Point3 = Vec3 = LineSegs = NodePath = None

--- a/tests/benchmarks/test_region_streaming_bench.py
+++ b/tests/benchmarks/test_region_streaming_bench.py
@@ -9,8 +9,8 @@ import pytest
 
 pytest.importorskip("pytest_benchmark")
 
-from runepy.world.region import Region
 from runepy.world.manager import RegionManager
+from runepy.world.region import Region
 
 
 def _prepare_region(tmp_path):

--- a/tests/test_array_map.py
+++ b/tests/test_array_map.py
@@ -1,5 +1,7 @@
 import os
+
 import numpy as np
+
 from runepy.array_map import RegionArrays
 
 

--- a/tests/test_controls.py
+++ b/tests/test_controls.py
@@ -1,5 +1,7 @@
 from panda3d.core import NodePath
+
 from runepy.controls import Controls
+
 
 class CamControl:
     def __init__(self, camera):

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -1,5 +1,5 @@
 from constants import REGION_SIZE
-from runepy.world.region import world_to_region, local_tile
+from runepy.world.region import local_tile, world_to_region
 
 
 def round_trip(x, y):

--- a/tests/test_debug_stub.py
+++ b/tests/test_debug_stub.py
@@ -1,5 +1,6 @@
 import runepy.debug as dbg
 
+
 def test_debug_stub():
     d = dbg.get_debug()
     assert hasattr(d, 'dump_console')

--- a/tests/test_editor_toolbar.py
+++ b/tests/test_editor_toolbar.py
@@ -1,5 +1,6 @@
 from runepy.editor_toolbar import EditorToolbar
 
+
 class StubFrame:
     def __init__(self, **kw):
         self.kw = kw

--- a/tests/test_editor_window_click_override.py
+++ b/tests/test_editor_window_click_override.py
@@ -1,7 +1,9 @@
 import types
-from runepy.texture_editor import TextureEditor
 
 from panda3d.core import NodePath
+
+from runepy.texture_editor import TextureEditor
+
 
 class _FakeBase:
     def __init__(self):

--- a/tests/test_editor_window_method_handler.py
+++ b/tests/test_editor_window_method_handler.py
@@ -1,6 +1,9 @@
 import types
-from runepy.texture_editor import TextureEditor
+
 from panda3d.core import NodePath
+
+from runepy.texture_editor import TextureEditor
+
 
 class _MethodBase:
     def __init__(self):

--- a/tests/test_keybinding_manager.py
+++ b/tests/test_keybinding_manager.py
@@ -1,5 +1,7 @@
 import types
+
 from runepy.options_menu import KeyBindingManager
+
 
 class FakeBase:
     def __init__(self):

--- a/tests/test_map_editor.py
+++ b/tests/test_map_editor.py
@@ -1,17 +1,16 @@
-import types
 import importlib
+import types
+
+from runepy.map_editor import MapEditor
+from runepy.paths import MAPS_DIR
+from runepy.terrain import FLAG_BLOCKED
+from runepy.world.world import World
 
 modules = [
     'runepy.map_editor',
 ]
 for mod in modules:
     importlib.import_module(mod)
-
-from runepy.map_editor import MapEditor
-from runepy.paths import MAPS_DIR
-from runepy.world.world import World
-from runepy.terrain import FLAG_BLOCKED
-
 
 class _FakeClient:
     def __init__(self):

--- a/tests/test_options_menu.py
+++ b/tests/test_options_menu.py
@@ -1,5 +1,7 @@
 import types
-from runepy.options_menu import OptionsMenu, KeyBindingManager
+
+from runepy.options_menu import KeyBindingManager, OptionsMenu
+
 
 class FakeBase:
     def __init__(self):

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -1,6 +1,7 @@
 import numpy as np
-from runepy.world.region import Region
+
 from constants import REGION_SIZE
+from runepy.world.region import Region
 
 
 def test_region_edit_round_trip(tmp_path, monkeypatch):

--- a/tests/test_region_bin.py
+++ b/tests/test_region_bin.py
@@ -1,9 +1,10 @@
 import gzip
 
-from runepy.paths import MAPS_DIR
 import numpy as np
-from runepy.world.region import Region
+
 from constants import REGION_SIZE
+from runepy.paths import MAPS_DIR
+from runepy.world.region import Region
 
 
 def test_region_round_trip(tmp_path, monkeypatch):

--- a/tests/test_region_manager.py
+++ b/tests/test_region_manager.py
@@ -1,7 +1,8 @@
 import numpy as np
+
+from constants import REGION_SIZE
 from runepy.world.manager import RegionManager
 from runepy.world.region import Region
-from constants import REGION_SIZE
 
 
 def test_region_manager_loading(tmp_path, monkeypatch):

--- a/tests/test_regionarrays_io.py
+++ b/tests/test_regionarrays_io.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from runepy.array_map import RegionArrays
 
 

--- a/tests/test_terrain_tile.py
+++ b/tests/test_terrain_tile.py
@@ -1,4 +1,4 @@
-from runepy.terrain import TerrainTile, FLAG_BLOCKED
+from runepy.terrain import FLAG_BLOCKED, TerrainTile
 
 
 def test_terrain_tile_flags_and_values():

--- a/tests/test_texture_editor.py
+++ b/tests/test_texture_editor.py
@@ -1,6 +1,8 @@
 import types
-from runepy.world.world import World
+
 from runepy.map_editor import MapEditor
+from runepy.world.world import World
+
 
 class StubFrame:
     def __init__(self, **kw):

--- a/tests/test_texture_editor_click_override.py
+++ b/tests/test_texture_editor_click_override.py
@@ -1,6 +1,8 @@
 import types
-from runepy.world.world import World
+
 from runepy.texture_editor import TextureEditor
+from runepy.world.world import World
+
 
 class _FakeBase:
     def __init__(self):

--- a/tests/test_texture_editor_method_handler.py
+++ b/tests/test_texture_editor_method_handler.py
@@ -1,6 +1,8 @@
 import types
-from runepy.world.world import World
+
 from runepy.texture_editor import TextureEditor
+from runepy.world.world import World
+
 
 class _MethodBase:
     def __init__(self):

--- a/tests/test_texture_editor_other_handlers.py
+++ b/tests/test_texture_editor_other_handlers.py
@@ -1,6 +1,8 @@
 import types
-from runepy.world.world import World
+
 from runepy.texture_editor import TextureEditor
+from runepy.world.world import World
+
 
 class _MultiBase:
     def __init__(self):

--- a/tests/test_tiledata.py
+++ b/tests/test_tiledata.py
@@ -1,5 +1,6 @@
 from runepy.world.world import TileData
 
+
 def test_tiledata_round_trip_custom_props():
     tile = TileData(walkable=False, description="foo", properties={"cost": 5})
     data = tile.to_dict()

--- a/tests/test_ui_builder_full.py
+++ b/tests/test_ui_builder_full.py
@@ -1,5 +1,6 @@
 from runepy.ui import builder
 
+
 class FakeWidget:
     def __init__(self, **kw):
         self.kw = kw

--- a/tests/test_ui_editor_extra.py
+++ b/tests/test_ui_editor_extra.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from runepy.ui.editor import controller as ctr
 
+
 class FakeWidget:
     def __init__(self, pos=(0,0,0), frame=(-0.5,0.5,-0.5,0.5)):
         self._pos = list(pos)

--- a/tests/test_ui_manager.py
+++ b/tests/test_ui_manager.py
@@ -1,7 +1,7 @@
-from pathlib import Path
 import json
-from runepy.ui.debug_layout import LAYOUT as DEBUG_LAYOUT
+from pathlib import Path
 
+from runepy.ui.debug_layout import LAYOUT as DEBUG_LAYOUT
 from runepy.ui.manager import UIManager
 
 

--- a/tests/test_verbose.py
+++ b/tests/test_verbose.py
@@ -1,5 +1,6 @@
 import sys
-from runepy.verbose import enable, disable
+
+from runepy.verbose import disable, enable
 
 
 def test_verbose_enable_disable():

--- a/tests/test_world_streaming.py
+++ b/tests/test_world_streaming.py
@@ -1,7 +1,8 @@
 import numpy as np
+
 from constants import REGION_SIZE
-from runepy.world.world import World
 from runepy.terrain import FLAG_BLOCKED
+from runepy.world.world import World
 
 
 def test_update_streaming_calls_ensure(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- reorder imports across project
- ensure imports appear before executable code and are sorted

## Testing
- `ruff check --select I001,E402 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a33c1c3d04832e87549bef8bfca4c1