### PR TITLE
chore: remove unused imports

### DIFF
--- a/src/runepy/map_editor.py
+++ b/src/runepy/map_editor.py
@@ -1,7 +1,6 @@
 import logging
 
 from constants import REGION_SIZE
-from runepy.terrain import FLAG_BLOCKED
 from runepy.texture_editor import TextureEditor
 from runepy.utils import get_tile_from_mouse
 from runepy.world.region import local_tile, world_to_region

--- a/src/runepy/map_manager.py
+++ b/src/runepy/map_manager.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, Tuple
+from typing import Tuple
 
 from .array_map import RegionArrays
 from .world.base_manager import BaseRegionManager

--- a/src/runepy/options_menu.py
+++ b/src/runepy/options_menu.py
@@ -1,11 +1,5 @@
 import copy
 
-from direct.gui.DirectGui import (
-    DirectButton,
-    DirectEntry,
-    DirectFrame,
-    DirectLabel,
-)
 from direct.showbase.DirectObject import DirectObject
 from panda3d.core import TextNode
 

--- a/src/runepy/world/manager.py
+++ b/src/runepy/world/manager.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from concurrent.futures import Future, ThreadPoolExecutor
-from typing import Dict, Set, Tuple
+from typing import Dict, Tuple
 
 from constants import REGION_SIZE, VIEW_RADIUS
 

--- a/tests/test_array_map.py
+++ b/tests/test_array_map.py
@@ -1,6 +1,4 @@
-import os
 
-import numpy as np
 
 from runepy.array_map import RegionArrays
 

--- a/tests/test_keybinding_manager.py
+++ b/tests/test_keybinding_manager.py
@@ -1,4 +1,3 @@
-import types
 
 from runepy.options_menu import KeyBindingManager
 

--- a/tests/test_options_menu.py
+++ b/tests/test_options_menu.py
@@ -1,4 +1,3 @@
-import types
 
 from runepy.options_menu import KeyBindingManager, OptionsMenu
 

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-from constants import REGION_SIZE
 from runepy.world.region import Region
 
 

--- a/tests/test_region_manager.py
+++ b/tests/test_region_manager.py
@@ -1,8 +1,6 @@
-import numpy as np
 
 from constants import REGION_SIZE
 from runepy.world.manager import RegionManager
-from runepy.world.region import Region
 
 
 def test_region_manager_loading(tmp_path, monkeypatch):

--- a/tests/test_texture_editor_click_override.py
+++ b/tests/test_texture_editor_click_override.py
@@ -1,4 +1,3 @@
-import types
 
 from runepy.texture_editor import TextureEditor
 from runepy.world.world import World

--- a/tests/test_texture_editor_method_handler.py
+++ b/tests/test_texture_editor_method_handler.py
@@ -1,4 +1,3 @@
-import types
 
 from runepy.texture_editor import TextureEditor
 from runepy.world.world import World

--- a/tests/test_texture_editor_other_handlers.py
+++ b/tests/test_texture_editor_other_handlers.py
@@ -1,4 +1,3 @@
-import types
 
 from runepy.texture_editor import TextureEditor
 from runepy.world.world import World

--- a/tests/test_ui_editor_extra.py
+++ b/tests/test_ui_editor_extra.py
@@ -1,4 +1,3 @@
-import importlib
 from pathlib import Path
 
 from runepy.ui.editor import controller as ctr

--- a/tests/test_world_streaming.py
+++ b/tests/test_world_streaming.py
@@ -1,4 +1,3 @@
-import numpy as np
 
 from constants import REGION_SIZE
 from runepy.terrain import FLAG_BLOCKED


### PR DESCRIPTION
## Summary
- remove unreferenced imports flagged by Ruff F401 across modules and tests

## Testing
- `ruff check --select F401 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a33dff79e4832e8f03de52fd852ea7