### PR TITLE
refactor: move ruff lint config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ show_missing = true
 [tool.ruff]
 line-length = 88
 target-version = "py311"
+
+
+[tool.ruff.lint]
 select = ["E", "F", "B", "I"]
 ignore = ["E501"]
 


### PR DESCRIPTION
## Summary
- move ruff lint settings to new `[tool.ruff.lint]` table

## Testing
- `ruff check`


------
https://chatgpt.com/codex/tasks/task_e_68a732b93bc4832ea63cd12bffcfc0be