### PR TITLE
Ensure benchmarks skip without pytest-benchmark

### DIFF
--- a/tests/benchmarks/test_pathfinding_bench.py
+++ b/tests/benchmarks/test_pathfinding_bench.py
@@ -12,13 +12,11 @@ optimisation):
 - 200×200 grid: ~6.79 ms
 """
 
+import numpy as np
 import pytest
+from runepy.pathfinding import a_star
 
 pytest.importorskip("pytest_benchmark")
-
-import numpy as np
-
-from runepy.pathfinding import a_star
 
 
 def _run_a_star(size: int) -> None:

--- a/tests/benchmarks/test_region_streaming_bench.py
+++ b/tests/benchmarks/test_region_streaming_bench.py
@@ -6,11 +6,10 @@ previously loaded regions in memory.
 """
 
 import pytest
-
-pytest.importorskip("pytest_benchmark")
-
 from runepy.world.manager import RegionManager
 from runepy.world.region import Region
+
+pytest.importorskip("pytest_benchmark")
 
 
 def _prepare_region(tmp_path):


### PR DESCRIPTION
## Summary
- consolidate benchmark imports at top of modules
- check for `pytest_benchmark` after imports to skip benchmarks

## Testing
- `pytest tests/benchmarks -vv -rs`

------
https://chatgpt.com/codex/tasks/task_e_68a73bd78f40832e8e4b5ff85a20c7ff