### PR TITLE
chore: remove tooling config and optional test deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,6 @@ dependencies = [
     "numpy",
 ]
 
-[project.optional-dependencies]
-test = [
-    "pytest-benchmark",
-]
-
 [project.scripts]
 runepy = "runepy.client:main"
 
@@ -29,26 +24,4 @@ include = ["runepy*"]
 
 [tool.setuptools]
 py-modules = ["constants"]
-
-[tool.coverage.run]
-branch = true
-source = ["runepy"]
-
-[tool.coverage.report]
-fail_under = 85
-show_missing = true
-
-[tool.ruff]
-line-length = 88
-target-version = "py311"
-
-[tool.ruff.lint]
-select = ["E", "F", "B", "I"]
-ignore = ["E501"]
-
-[tool.mypy]
-python_version = "3.11"
-disallow_untyped_defs = true
-ignore_missing_imports = true
-exclude = ["tests/"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 Panda3D==1.10.15
 numpy==1.26.4
-pytest-benchmark==5.1.0


### PR DESCRIPTION
## Summary
- remove coverage, ruff, mypy sections from pyproject
- drop pytest-benchmark optional test dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a76d9d4590832eb42d0ea7522cbdce